### PR TITLE
Change to code reminder

### DIFF
--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -533,7 +533,7 @@ namespace DiscordBot
 
                     await messageParam.Channel.SendMessageAsync(sb.ToString()).DeleteAfterTime(minutes: 10);
                 }
-                else if (foundCodeTags && foundCurlyFries && content.Contains("```") && !content.Contains("```cs"))
+                else if (foundCodeTags && foundCurlyFries && content.Contains("```") && !content.ToLower().Contains("```cs"))
                 {
                     StringBuilder sb = new StringBuilder();
                     sb.Append(messageParam.Author.Mention)


### PR DESCRIPTION
```Cs
The "cs" part should be case insensitive, but it checks only if the content doesn't contain "cs", adding content.ToLower().Contains should fix this.