### PR TITLE
Ticketing Complaints

### DIFF
--- a/DiscordBot.csproj
+++ b/DiscordBot.csproj
@@ -4,12 +4,12 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00933" />
+    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00970" />
     <PackageReference Include="HtmlAgilityPack" Version="1.8.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.0.3" />
     <PackageReference Include="MySql.Data" Version="8.0.9-dmr" />
     <PackageReference Include="NETCore.MailKit" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1-beta1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="ScrapySharp" Version="2.6.2" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="ImageSharp" Version="1.0.0-*" />

--- a/Modules/TicketModule.cs
+++ b/Modules/TicketModule.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using DiscordBot.Extensions;
+
+// ReSharper disable all UnusedMember.Local
+namespace DiscordBot.Modules {
+    public class TicketModule : ModuleBase {
+        
+        /// <summary>
+        /// Creates a private channel only accessable by the mods, admins, and the user who used the command.
+        ///
+        /// One command, no args, simple.
+        /// </summary>
+        [Command("complaint"), Alias("complain", "new", "whine", "bitch", "moan"), Summary("Opens a private channel to complain.")]
+        [RequireBotPermission(GuildPermission.SendMessages)]
+        private async Task Complaint () {
+            var channelList = Context.Guild.GetChannelsAsync().Result;
+            var channelName = ParseToDiscordChannel($"{SettingsHandler.LoadValueString("complaintChannelPrefix", JsonFile.Settings)}-{Context.User.Username}");
+            var categoryExists = false;
+            var categoryList = Context.Guild.GetCategoriesAsync().Result;
+            var categoryName = SettingsHandler.LoadValueString("complaintCategoryName", JsonFile.Settings);
+            
+            var everyonePerms = new OverwritePermissions(viewChannel: PermValue.Deny);
+            var userPerms = new OverwritePermissions(viewChannel: PermValue.Allow);
+
+            ulong? categoryId = null;
+
+            await Context.Message.DeleteAsync();
+
+            foreach (var category in categoryList) {
+                if (string.Equals(category.Name, categoryName, StringComparison.CurrentCultureIgnoreCase)) {
+                    categoryId = category.Id;
+                    categoryExists = true;
+                    break;
+                }
+            }
+
+            if (!categoryExists) {
+                var category = Context.Guild.CreateCategoryAsync(categoryName);
+                categoryId = category.Result.Id;
+            }
+
+            if (channelList.Any(channel => channel.Name == channelName)) {
+                await ReplyAsync($"{Context.User.Mention}, you already have an open complaint! Please use that channel!").DeleteAfterSeconds(15);
+                return;
+            }
+
+            var newChannel = await Context.Guild.CreateTextChannelAsync(channelName, x =>
+                x.CategoryId = categoryId
+            );
+
+            await newChannel.AddPermissionOverwriteAsync(Context.Guild.EveryoneRole, everyonePerms);
+            await newChannel.AddPermissionOverwriteAsync(Context.User, userPerms);
+
+            await newChannel.SendMessageAsync(
+                $"{Context.User.Mention}, this is your chat to voice your complaint to the staff members. When everything is finished between you and the staff, please do !close!");
+        }
+
+        /// <summary>
+        /// Closes the ticket. No check on who used it, as unless a member of staff changes permissions, the only ones able to use this in a complaint
+        /// channel is the user who created the channel and staff.
+        /// </summary>
+        [Command("close"), Alias("end", "done", "bye"), Summary("Closes the ticket")]
+        [RequireBotPermission(GuildPermission.SendMessages)]
+        private async Task Close () {
+            var channelName = SettingsHandler.LoadValueString("complaintChannelPrefix", JsonFile.Settings);
+            
+            await Context.Message.DeleteAsync();
+            
+            if (Context.Channel.Name.StartsWith(channelName.ToLower())) {
+                await Context.Guild.GetChannelAsync(Context.Channel.Id).Result.DeleteAsync();
+            }
+        }
+
+        private string ParseToDiscordChannel (string channelName) => channelName.ToLower().Replace(" ", "-");
+    }
+}

--- a/Settings/Settings.example.json
+++ b/Settings/Settings.example.json
@@ -151,6 +151,10 @@
   "streamingRoleID": "233830762883842048",
   "streamerRoleID": "233814950710214659",
   "publisherRoleID": "206830803575898112",
+  "staffRoleId": "460573273134989313",
   /*Publisher Stuff*/
-  "assetStoreFrontPage": "https://www.assetstore.unity3d.com/en/"
+  "assetStoreFrontPage": "https://www.assetstore.unity3d.com/en/",
+  /*Complaints Channels Stuff*/
+  "complaintCategoryName": "Complaints",
+  "complaintChannelPrefix": "Complaint"
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19292389/41863507-a4ebd21e-786c-11e8-81e0-02859362299d.png)
Discussion about this feature.

Added commands:
!new (+ aliases): Creates a private channel to discuss complaints to the staff.
!close (+ aliases): Deletes the private channel after everything is done.

How it works:
1. User types `!new` or any of the aliases
2. If Complaints Category (the name is configurable in settings.json) is nonexistent, creates it.
3. If the private channel (prefix is configurable in settings.json) is nonexistent, creates it
4. Discussion
5. User or staff member types `!close` or any of the aliases
6. Channel is deleted