### PR TITLE
Rounded down the % in profile card

### DIFF
--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -314,7 +314,7 @@ namespace DiscordBot.Services
             uint xpShown = (uint) (xpTotal - xpLow);
             uint maxXpShown = (uint) (xpHigh - xpLow);
 
-            float percentage = (float) xpShown / maxXpShown;
+            float percentage = (float) Math.Floor((float) xpShown / maxXpShown);
 
             var u = user as IGuildUser;
             IRole mainRole = null;


### PR DESCRIPTION
To avoid showing "100%" when it's not 100% yet.
Example : 
![image](https://user-images.githubusercontent.com/1756398/44617727-76eb5700-a868-11e8-877f-e1c76866d9c5.png)
