### PR TITLE
Rounded down the % in profile card

### DIFF
--- a/Skin/XpBarInfoSkinModule.cs
+++ b/Skin/XpBarInfoSkinModule.cs
@@ -7,7 +7,7 @@ namespace DiscordBot.Skin
     {
         public override Drawables GetDrawables(ProfileData data)
         {
-            Text = $"{data.XpShown:#,##0} / {data.MaxXpShown:N0} ({(data.XpPercentage * 100):0}%)";
+            Text = $"{data.XpShown:#,##0} / {data.MaxXpShown:N0} ({Math.Floor(data.XpPercentage * 100):0}%)";
             return base.GetDrawables(data);
         }
 


### PR DESCRIPTION
To avoid showing "100%" when it's not 100% yet.
See: 
![image](https://user-images.githubusercontent.com/1756398/44617875-c2ebcb00-a86b-11e8-8b10-2be1a71ad660.png)
