### PR TITLE
(Old) Reaction Based Role system

### DIFF
--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -34,6 +34,7 @@ namespace DiscordBot
         private AnimeService _animeService;
         private FeedService _feedService;
         private CurrencyService _currencyService;
+        private ReactRoleService _reactRoleService;
 
         private static PayWork _payWork;
         private static Rules _rules;
@@ -66,6 +67,8 @@ namespace DiscordBot
             _audioService = new AudioService(_loggingService, _client, _settings);
             _currencyService = new CurrencyService();
             _serviceCollection = new ServiceCollection();
+            _reactRoleService = new ReactRoleService(_client, _loggingService, _settings);
+
             _serviceCollection.AddSingleton(_loggingService);
             _serviceCollection.AddSingleton(_databaseService);
             _serviceCollection.AddSingleton(_userService);
@@ -80,6 +83,7 @@ namespace DiscordBot
             _serviceCollection.AddSingleton(_payWork);
             _serviceCollection.AddSingleton(_userSettings);
             _serviceCollection.AddSingleton(_currencyService);
+            _serviceCollection.AddSingleton(_reactRoleService);
             _services = _serviceCollection.BuildServiceProvider();
 
 

--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -42,16 +42,26 @@ namespace DiscordBot.Services
             _client.Ready += ClientIsReady;
         }
 
+        private void LoadSettings()
+        {
+            try
+            {
+                using (var file = File.OpenText(@"Settings/ReactionRoles.json"))
+                {
+                    _reactSettings = JsonConvert.DeserializeObject<ReactRoleSettings>(file.ReadToEnd());
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to Deserialize 'ReactionRoles.Json' err: {ex.Message}");
+                isRunning = false;
+            }
+        }
+
         private async Task ClientIsReady()
         {
             // This could be with all the others loading, but self-managed seems cleaner.
-            using (var file = File.OpenText(@"Settings/ReactionRoles.json"))
-            {
-                _reactSettings = JsonConvert.DeserializeObject<ReactRoleSettings>(file.ReadToEnd());
-            }
-            //TODO We should probably do a bit more than just check if the file existed
-            if (_reactSettings != null)
-                isRunning = false;
+            LoadSettings();
             // Get the main channel we use
             _messageChannel = _client.GetChannel(_reactSettings.ChannelIndex) as IMessageChannel;
             // Get our Emotes

--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -16,6 +16,7 @@ namespace DiscordBot.Services
     class ReactRoleService
     {
         private ReactRoleSettings _reactSettings;
+        private bool isRunning = false;
 
         private readonly Settings.Deserialized.Settings _settings;
         private readonly DiscordSocketClient _client;
@@ -48,7 +49,9 @@ namespace DiscordBot.Services
             {
                 _reactSettings = JsonConvert.DeserializeObject<ReactRoleSettings>(file.ReadToEnd());
             }
-            //TODO Should probably log if this is valid or not
+            //TODO We should probably do a bit more than just check if the file existed
+            if (_reactSettings != null)
+                isRunning = false;
             // Get the main channel we use
             _messageChannel = _client.GetChannel(_reactSettings.ChannelIndex) as IMessageChannel;
             // Get our Emotes
@@ -85,6 +88,8 @@ namespace DiscordBot.Services
 
         private async Task ReationAdded(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
+            if (!isRunning)
+                return;
             if (ReactMessages.ContainsKey(message.Id))
             {
                 IGuildUser user = reaction.User.Value as IGuildUser;
@@ -109,6 +114,8 @@ namespace DiscordBot.Services
 
         private async Task ReactionRemoved(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
+            if (!isRunning)
+                return;
             if (ReactMessages.ContainsKey(message.Id))
             {
                 IGuildUser user = reaction.User.Value as IGuildUser;

--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -1,0 +1,137 @@
+﻿using Discord;
+using Discord.WebSocket;
+using DiscordBot.Extensions;
+using DiscordBot.Settings.Deserialized;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+
+namespace DiscordBot.Services
+{
+    class ReactRoleService
+    {
+        private readonly ulong MsgIndex = 603187631982903296; //TODO Add to settings?
+        private readonly ulong MsgChannel = 603187532078776340; //TODO Add to settings?
+
+        private IUserMessage _reactMessage = null;
+
+        private readonly Settings.Deserialized.Settings _settings;
+        private readonly DiscordSocketClient _client;
+        private readonly ILoggingService _loggingService;
+
+        private IMessageChannel _msgChannel = null;
+        private IGuild _serverGuild;
+
+        private UserReactRoles ReactRoles = null;
+
+        private Dictionary<string, GuildEmote> ReactEmojis = new Dictionary<string, GuildEmote>();
+        private Dictionary<string, IRole> EmojiRoles = new Dictionary<string, IRole>();
+        private Dictionary<string, ulong> EmojiRoleID = new Dictionary<string, ulong>();
+
+        public ReactRoleService(DiscordSocketClient client, ILoggingService logging, Settings.Deserialized.Settings settings)
+        {
+            _loggingService = logging;
+            _settings = settings;
+
+            _client = client;
+            _client.ReactionAdded += ReationAdded;
+            _client.ReactionRemoved += ReactionRemoved;
+
+            // Event so we can Initialize
+            _client.Ready += ClientIsReady;
+
+            // Pull our junk from Settings
+            ReactRoles = _settings.ReactRoles;
+        }
+
+        private async Task ClientIsReady()
+        {
+            _serverGuild = _client.GetGuild(_settings.guildId);
+            if (_serverGuild == null)
+            {
+                //TODO Log this shit
+            }
+            // Get our Emotes
+            for (int i = 0; i < ReactRoles.RoleCount(); i++)
+            {
+                ReactEmojis.Add(ReactRoles.EmojiID[i], await _serverGuild.GetEmoteAsync(ulong.Parse(ReactRoles.EmojiID[i])));
+                EmojiRoles.Add(ReactEmojis[ReactRoles.EmojiID[i]].Name, _serverGuild.GetRole(ulong.Parse(ReactRoles.RoleID[i])));
+                EmojiRoleID.Add(ReactEmojis[ReactRoles.EmojiID[i]].Name, ulong.Parse(ReactRoles.RoleID[i]));
+                // We should add some more debugging for both of these
+            }
+
+            _msgChannel = _client.GetChannel(MsgChannel) as IMessageChannel;
+            if (_msgChannel == null)
+            {
+                //TODO Log this shit
+            }
+            _reactMessage = await _msgChannel.GetMessageAsync(MsgIndex) as IUserMessage;
+            if (_reactMessage == null)
+            {
+                //TODO log this shit
+            }
+            else
+            {
+                List<GuildEmote> MissingEmojis = new List<GuildEmote>();
+                for (int i = 0; i < ReactRoles.RoleCount(); i++)
+                {
+                    // Role Emoji not added
+                    if (!_reactMessage.Reactions.ContainsKey(ReactEmojis[ReactRoles.EmojiID[i]]))
+                    {
+                        MissingEmojis.Add(ReactEmojis[ReactRoles.EmojiID[i]]);
+                    }
+                }
+                // We Apply all missing Emojis
+                //TODO Should log the missing emojis?
+                if (MissingEmojis.Count > 0)
+                    await _reactMessage.AddReactionsAsync(MissingEmojis.ToArray());
+
+                //? We could check if the message has more reacts than we have emojis and delete any extra emojis?
+
+                // Just to reduce our RateLimit potential we self-limit
+                // Timer t = new Timer(30000);
+                // t.Elapsed += ReminderCheck;
+                // t.Start();
+            }
+        }
+
+        private async Task ReationAdded(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            if (message.Id != MsgIndex)
+                return;
+            if (reaction.User.Value.IsBot)
+                return;
+
+            IGuildUser user = reaction.User.Value as IGuildUser;
+            if (EmojiRoles.ContainsKey(reaction.Emote.Name))
+            {
+                if (user.RoleIds.Contains(EmojiRoleID[reaction.Emote.Name]))
+                {
+                    return;
+                }
+                await user.AddRoleAsync(EmojiRoles[reaction.Emote.Name]);
+            }
+        }
+
+        private async Task ReactionRemoved(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            if (message.Id != MsgIndex)
+                return;
+            if (reaction.User.Value.IsBot)
+                return;
+
+            IGuildUser user = reaction.User.Value as IGuildUser;
+            if (EmojiRoles.ContainsKey(reaction.Emote.Name))
+            {
+                if (!user.RoleIds.Contains(EmojiRoleID[reaction.Emote.Name]))
+                {
+                    return;
+                }
+                await user.RemoveRoleAsync(EmojiRoles[reaction.Emote.Name]);
+            }
+        }
+    }
+}

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -28,6 +28,8 @@ namespace DiscordBot.Settings.Deserialized
 
         public AllRoles AllRoles { get; set; }
 
+        public UserReactRoles ReactRoles { get; set; }
+
         public RolesBanned RolesBanned { get; set; }
 
         public RolesModeration RolesModeration { get; set; }
@@ -90,6 +92,14 @@ namespace DiscordBot.Settings.Deserialized
         public List<string> Roles { get; set; }
     }
 
+    public class UserReactRoles
+    {
+        public string Desc { get; set; }
+        public List<string> RoleID { get; set; }
+        public List<string> EmojiID { get; set; }
+
+        public int RoleCount() { return RoleID.Count; }
+    }
 
     public class RolesBanned
     {

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -28,8 +28,6 @@ namespace DiscordBot.Settings.Deserialized
 
         public AllRoles AllRoles { get; set; }
 
-        public UserReactRoles ReactRoles { get; set; }
-
         public RolesBanned RolesBanned { get; set; }
 
         public RolesModeration RolesModeration { get; set; }

--- a/DiscordBot/Settings/ReactionRoles.json
+++ b/DiscordBot/Settings/ReactionRoles.json
@@ -1,0 +1,79 @@
+{
+  "ChannelIndex": "493510975006441473", // This is #Welcome
+  "LogUpdates": "false", // If you want it to spam #bot-announcement
+  "UserReactRoleList": [
+    {
+      "MessageIndex": "YOU_NEED_A_MESSAGE",
+      "Desc": "Technical Reactions",
+      "Reactions": [
+        {
+          // Programmer
+          "RoleID": "493514653683679233",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // Audio Engineer
+          "RoleID": "493515056965746689",
+          "EmojiID": "603563809562558484"
+        },
+        {
+          // Technical Artist
+          "RoleID": "503265265723899925",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // XR Developer
+          "RoleID": "493514976430915605",
+          "EmojiID": "NeedEmote"
+        }
+      ]
+    },
+    {
+      "MessageIndex": "YOU_NEED_A_MESSAGE",
+      "Desc": "Artists Reactions",
+      "Reactions": [
+        {
+          // 2D Artist
+          "RoleID": "493514627846504460",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // 3D Artist
+          "RoleID": "493514904515379241",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // Animator
+          "RoleID": "503265592157929496",
+          "EmojiID": "NeedEmote"
+        }
+      ]
+    },
+    {
+      "MessageIndex": "YOU_NEED_A_MESSAGE",
+      "Desc": "Design Reactions",
+      "Reactions": [
+        {
+          // Game Designer
+          "RoleID": "493514649367740427",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // Generalist
+          "RoleID": "493514865038721024",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // Hobbyist
+          "RoleID": "502592458241212427",
+          "EmojiID": "NeedEmote"
+        },
+        {
+          // Student
+          "RoleID": "493515090906316841",
+          "EmojiID": "NeedEmote"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A simple reaction based role system.

I've made it as simple as I could think to setup, all we/you need to do is add emoji to the server for each role we want this to support and then add the ID of the emoji to 'ReactionRoles.json'

**_I recommend naming them related to the role to reduce confusion as much as possible._**

Pretty simplistic management here, I have no idea how discords rate-limits will dislike this is someone spammed, it could be reduced a little bit, by logging changes and adding the roles every other second. But 🤷‍♂ , I can add that later, should that be a problem.

I have tested this and it works about as expected on my test server, the setup is a bit fiddly but I have tried to setup 'settings/ReactionRoles.json' as much as I could, just need to add emote ids and create a few messages for it to work on and move it to the runtime settings folder.