### PR TITLE
Fixed natural duration mute

### DIFF
--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -77,7 +77,7 @@ namespace DiscordBot.Modules
                     return;
                 }
 
-                await MuteUser(user, (uint) (dt - DateTime.Now).TotalSeconds, messages);
+                await MuteUser(user, (uint) Math.Round((dt - DateTime.Now).TotalSeconds), messages);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Since time pass as the line is processed, `DateTime.Now` has a new value when we do the difference.
And since `.TotalSeconds` returns a Decimal value, when casting it to a uint we get only the integer part which lack the few ms difference.

By rounding it we can avoid this small difference.