### PR TITLE
Reaction Roles now group update

### DIFF
--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -29,19 +29,34 @@ namespace DiscordBot.Services
         private Dictionary<ulong, IRole> GuildRoles = new Dictionary<ulong, IRole>();
         private Dictionary<ulong, GuildEmote> GuildEmotes = new Dictionary<ulong, GuildEmote>();
 
+        private Dictionary<IGuildUser, ReactRoleUserData> _pendingUserUpdate = new Dictionary<IGuildUser, ReactRoleUserData>();
+        class ReactRoleUserData
+        {
+            public IGuildUser user;
+            public DateTime lastChange = DateTime.Now;
+            public List<IRole> addRole = new List<IRole>();
+            public List<IRole> removeRole = new List<IRole>();
+            public ReactRoleUserData(IGuildUser id)
+            {
+                user = id;
+            }
+        }
+
         public ReactRoleService(DiscordSocketClient client, ILoggingService logging, Settings.Deserialized.Settings settings)
         {
             _loggingService = logging;
             _settings = settings;
 
             _client = client;
-            _client.ReactionAdded += ReationAdded;
+            _client.ReactionAdded += ReactionAdded;
             _client.ReactionRemoved += ReactionRemoved;
 
             // Event so we can Initialize
             _client.Ready += ClientIsReady;
         }
-
+        /// <summary>
+        /// Loads settings, this should just be message ids, and emotes/role ids
+        /// </summary>
         private void LoadSettings()
         {
             try
@@ -86,7 +101,7 @@ namespace DiscordBot.Services
                     {
                         GuildEmotes.Add(ReactList.Reactions[i].EmojiID, await ServerGuild.GetEmoteAsync(ReactList.Reactions[i].EmojiID));
                     }
-                    // If our message doesn't have the emote we've just added, we add it.
+                    // If our message doesn't have the emote, we add it.
                     if (!ReactMessages[ReactList.MessageIndex].Reactions.ContainsKey(GuildEmotes[ReactList.Reactions[i].EmojiID]))
                     {
                         // We could add these in bulk, but that'd require a bit more setup
@@ -94,63 +109,118 @@ namespace DiscordBot.Services
                     }
                 }
             }
+            isRunning = true;
         }
 
-        private async Task ReationAdded(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
+        private async Task ReactionAdded(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
             if (!isRunning)
                 return;
             if (ReactMessages.ContainsKey(message.Id))
             {
-                IGuildUser user = reaction.User.Value as IGuildUser;
-                if (IsUserValid(user))
-                {
-                    // Check if their emote relates to a role and apply them.
-                    Emote emote = reaction.Emote as Emote;
-                    IRole targetRole;
-                    if (GuildRoles.TryGetValue(emote.Id, out targetRole))
-                    {
-                        if (user.RoleIds.Contains(targetRole.Id))
-                        {
-                            return;
-                        }
-                        await user.AddRoleAsync(targetRole);
-                        if (_reactSettings.LogUpdates)
-                            await _loggingService.LogAction($"**{user.Username}** added role '**{targetRole.Name}**'.");
-                    }
-                }
+                ReactionChanged(reaction.User.Value as IGuildUser, reaction.Emote as Emote, true);
             }
         }
-
         private async Task ReactionRemoved(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
             if (!isRunning)
                 return;
             if (ReactMessages.ContainsKey(message.Id))
             {
-                IGuildUser user = reaction.User.Value as IGuildUser;
-                if (IsUserValid(user))
+                if (ReactMessages.ContainsKey(message.Id))
                 {
-                    // Check if their emote relates to a role and apply them.
-                    Emote emote = reaction.Emote as Emote;
-                    IRole targetRole;
-                    if (GuildRoles.TryGetValue(emote.Id, out targetRole))
-                    {
-                        if (!user.RoleIds.Contains(targetRole.Id))
-                        {
-                            return;
-                        }
-                        await user.RemoveRoleAsync(targetRole);
-                        if (_reactSettings.LogUpdates)
-                            await _loggingService.LogAction($"**{user.Username}** removed role '**{targetRole.Name}**'.");
-                    }
+                    ReactionChanged(reaction.User.Value as IGuildUser, reaction.Emote as Emote, false);
                 }
+            }
+        }
+        private void ReactionChanged(IGuildUser user, Emote emote, bool state)
+        {
+            if (IsUserValid(user))
+            {
+                IRole targetRole;
+                if (GuildRoles.TryGetValue(emote.Id, out targetRole))
+                {
+                    UpdatePendingRoles(user, targetRole, state);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Updates users roles in bulk, this prevents discord from crying.
+        /// </summary>
+        private async void UpdateUserRoles(IGuildUser user)
+        {
+            ReactRoleUserData userData;
+            if (_pendingUserUpdate.TryGetValue(user, out userData))
+            {
+                // Wait for a bit to give user to choose all their roles.
+                // we add a bit more to the end just so we don't always hit a second delay if they only selected 1 emote.
+                await Task.Delay(_reactSettings.RoleAddDelay + 250);
+                while (((DateTime.Now - userData.lastChange).TotalMilliseconds < _reactSettings.RoleAddDelay))
+                {
+                    await Task.Delay(2000);
+                }
+                // Strip out any changes we don't need to prevent additional calls
+                // If changes were made to either add or remove, we make those changes.
+                if (userData.addRole.Count > 0)
+                {
+                    for (int i = userData.addRole.Count - 1; i >= 0; i--)
+                    {
+                        if (user.RoleIds.Contains(userData.addRole[i].Id))
+                        {
+                            userData.addRole.RemoveAt(i);
+                        }
+                    }
+                    await user.AddRolesAsync(userData.addRole);
+                }
+                if (userData.removeRole.Count > 0)
+                {
+                    for (int i = userData.removeRole.Count - 1; i >= 0; i--)
+                    {
+                        if (user.RoleIds.Contains(userData.removeRole[i].Id))
+                        {
+                            userData.removeRole.RemoveAt(i);
+                        }
+                    }
+                    await user.RemoveRolesAsync(userData.removeRole);
+                }
+                if (_reactSettings.LogUpdates)
+                    await _loggingService.LogAction($"{user.Username} Updated Roles.", false, true);
+
+                _pendingUserUpdate.Remove(user);
+            }
+        }
+
+        /// <summary>
+        /// If a user is reacting to messages, they're added to a pending list of updates. Any time they react within the timeframe, it resets, and updates what roles need to be set.
+        /// </summary>
+        private void UpdatePendingRoles(IGuildUser user, IRole role, bool state)
+        {
+            // We check if the user has pending updates, if they don't we add them
+            if (!_pendingUserUpdate.ContainsKey(user))
+            {
+                _pendingUserUpdate.Add(user, new ReactRoleUserData(user));
+                UpdateUserRoles(user);
+            }
+            var userData = _pendingUserUpdate[user];
+            // Update Change to prevent spamming
+            userData.lastChange = DateTime.Now;
+            // Add our change, make sure it isn't in our RemoveList
+            if (state == true) 
+            { 
+                userData.addRole.Add(role);
+                userData.removeRole.Remove(role);
+            } 
+            else
+            {
+                userData.addRole.Remove(role);
+                userData.removeRole.Add(role);
             }
         }
 
         private bool IsUserValid(IGuildUser user)
         {
-            if (user.IsBot || user.RoleIds.Contains(_settings.MutedRoleId))
+            if (user.IsBot)
                 return false;
             return true;
         }
@@ -160,6 +230,7 @@ namespace DiscordBot.Services
     public class ReactRoleSettings
     {
         public ulong ChannelIndex;
+        public int RoleAddDelay = 5000;
         public bool LogUpdates;
         public List<UserReactRoles> UserReactRoleList;
     }

--- a/DiscordBot/Settings/ReactionRoles.json
+++ b/DiscordBot/Settings/ReactionRoles.json
@@ -1,5 +1,6 @@
 {
   "ChannelIndex": "493510975006441473", // This is #Welcome
+  "RoleAddDelay":  5000, // How long in seconds before changes are grouped together (Prevents easy abuse through throttle)
   "LogUpdates": "false", // If you want it to spam #bot-announcement
   "UserReactRoleList": [
     {


### PR DESCRIPTION
- Updates roles in groups with a default 5 second cooldown which should prevent most problems that can be introduced from reaction based role systems. ie; throttling
- Added a configable delay group time, 5 seconds seems decent though.
- Before editing roles, strips out any roles that don't need to be applied (already have/don't have role).
- Fixed a couple typos