### PR TITLE
Reply/CrossPost karma

### DIFF
--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.3.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.8.4" />
     <PackageReference Include="Magick.NET-Q8-x64" Version="7.5.0.1" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />

--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -40,7 +40,7 @@ namespace DiscordBot.Modules
         [Command("mute"), Summary("Mute a user for a fixed duration")]
         [Alias("shutup", "stfu")]
         [RequireStaff]
-        async Task MuteUser(IUser user, uint arg)
+        public async Task MuteUser(IUser user, uint arg)
         {
             await Context.Message.DeleteAsync();
 
@@ -66,7 +66,7 @@ namespace DiscordBot.Modules
         [Command("mute"), Summary("Mute a user for a fixed duration")]
         [Alias("shutup", "stfu")]
         [RequireStaff]
-        async Task MuteUser(IUser user, string naturalDuration, params string[] messages)
+        public async Task MuteUser(IUser user, string naturalDuration, params string[] messages)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace DiscordBot.Modules
         [Command("mute"), Summary("Mute a user for a fixed duration")]
         [Alias("shutup", "stfu")]
         [RequireStaff]
-        async Task MuteUser(IUser user, uint arg, params string[] messages)
+        public async Task MuteUser(IUser user, uint arg, params string[] messages)
         {
             string message = string.Join(' ', messages);
 
@@ -134,7 +134,7 @@ namespace DiscordBot.Modules
 
         [Command("unmute"), Summary("Unmute a muted user")]
         [RequireStaff]
-        async Task UnmuteUser(IUser user, bool fromMute = false)
+        public async Task UnmuteUser(IUser user, bool fromMute = false)
         {
             var u = user as IGuildUser;
 
@@ -157,7 +157,7 @@ namespace DiscordBot.Modules
         [Command("addrole"), Summary("Add a role to a user")]
         [Alias("roleadd")]
         [RequireStaff]
-        async Task AddRole(IRole role, IUser user)
+        public async Task AddRole(IRole role, IUser user)
         {
             var contextUser = Context.User as SocketGuildUser;
             await Context.Message.DeleteAsync();
@@ -178,7 +178,7 @@ namespace DiscordBot.Modules
         [Command("removerole"), Summary("Remove a role from a user")]
         [Alias("roleremove")]
         [RequireStaff]
-        async Task RemoveRole(IRole role, IUser user)
+        public async Task RemoveRole(IRole role, IUser user)
         {
             var contextUser = Context.User as SocketGuildUser;
             await Context.Message.DeleteAsync();
@@ -200,7 +200,7 @@ namespace DiscordBot.Modules
         [Command("clear"), Summary("Remove last x messages")]
         [Alias("clean", "nuke", "purge")]
         [RequireStaff]
-        async Task ClearMessages(int count)
+        public async Task ClearMessages(int count)
         {
             ITextChannel channel = Context.Channel as ITextChannel;
 
@@ -218,7 +218,7 @@ namespace DiscordBot.Modules
         [Command("clear"), Summary("Remove messages until the message at the specified id")]
         [Alias("clean", "nuke", "purge")]
         [RequireStaff]
-        async Task ClearMessages(ulong messageId)
+        public async Task ClearMessages(ulong messageId)
         {
             ITextChannel channel = Context.Channel as ITextChannel;
 
@@ -245,7 +245,7 @@ namespace DiscordBot.Modules
 
         [Command("ban"), Summary("Ban an user")]
         [RequireUserPermission(GuildPermission.BanMembers)]
-        async Task BanUser(IUser user, params string[] reasons)
+        public async Task BanUser(IUser user, params string[] reasons)
         {
             string reason = string.Join(' ', reasons);
             await Context.Guild.AddBanAsync(user, 7, reason, RequestOptions.Default);
@@ -254,7 +254,7 @@ namespace DiscordBot.Modules
 
         [Command("debug"), Summary("Debug")]
         [RequireUserPermission(GuildPermission.BanMembers)]
-        async Task Debug(IUser user)
+        public async Task Debug(IUser user)
         {
             var guildUser = (IGuildUser) user;
             await ReplyAsync(guildUser.RoleIds.Count.ToString());
@@ -262,7 +262,7 @@ namespace DiscordBot.Modules
 
         [Command("rules"), Summary("Display rules of the current channel.")]
         [RequireStaff]
-        async Task Rules(int seconds = 60)
+        public async Task Rules(int seconds = 60)
         {
             Rules(Context.Channel, seconds);
             await Context.Message.DeleteAsync();
@@ -270,7 +270,7 @@ namespace DiscordBot.Modules
 
         [Command("rules"), Summary("Display rules of the mentionned channel.")]
         [RequireStaff]
-        async Task Rules(IMessageChannel channel, int seconds = 60)
+        public async Task Rules(IMessageChannel channel, int seconds = 60)
         {
             //Display rules of this channel for x seconds
             var rule = _rules.Channel.First(x => x.Id == 0);
@@ -296,7 +296,7 @@ namespace DiscordBot.Modules
 
         [Command("globalrules"), Summary("Display globalrules in current channel.")]
         [RequireStaff]
-        async Task GlobalRules(int seconds = 60)
+        public async Task GlobalRules(int seconds = 60)
         {
             //Display rules of this channel for x seconds
             string globalRules = _rules.Channel.First(x => x.Id == 0).Content;
@@ -311,7 +311,7 @@ namespace DiscordBot.Modules
 
         [Command("channels"), Summary("Get a description of the channels.")]
         [RequireStaff]
-        async Task ChannelsDescription(int seconds = 60)
+        public async Task ChannelsDescription(int seconds = 60)
         {
             //Display rules of this channel for x seconds
             var channelData = _rules.Channel;
@@ -345,7 +345,7 @@ namespace DiscordBot.Modules
 
         [Command("slowmode"), Summary("Put on slowmode.")]
         [RequireStaff]
-        async Task SlowMode(int time)
+        public async Task SlowMode(int time)
         {
             await Context.Message.DeleteAsync();
             await (Context.Channel as ITextChannel).ModifyAsync(p => p.SlowModeInterval = time);
@@ -355,7 +355,7 @@ namespace DiscordBot.Modules
         [Command("tagrole"), Summary("Tag a role and post a message.")]
         [Alias("mentionrole", "pingrole", "rolemention", "roletag", "roleping")]
         [RequireUserPermission(GuildPermission.Administrator)]
-        async Task TagRole(IRole role, params string[] messages)
+        public async Task TagRole(IRole role, params string[] messages)
         {
             string message = String.Join(' ', messages);
             var isMentionable = role.IsMentionable;
@@ -402,7 +402,7 @@ namespace DiscordBot.Modules
         [Command("closepoll"), Summary("Close a poll and append a message.")]
         [Alias("pollclose")]
         [RequireUserPermission(GuildPermission.Administrator)]
-        async Task ClosePoll(IMessageChannel channel, ulong messageId, params string[] additionalNotes)
+        public async Task ClosePoll(IMessageChannel channel, ulong messageId, params string[] additionalNotes)
         {
             string additionalNote = String.Join(' ', additionalNotes);
             var message = (IUserMessage) await channel.GetMessageAsync(messageId);
@@ -421,7 +421,7 @@ namespace DiscordBot.Modules
 
         [Command("ad"), Summary("Post ad with databaseid")]
         [RequireUserPermission(GuildPermission.Administrator)]
-        async Task PostAd(uint dbId)
+        public async Task PostAd(uint dbId)
         {
             await _publisher.PostAd(dbId);
             await ReplyAsync("Ad posted.");
@@ -429,7 +429,7 @@ namespace DiscordBot.Modules
 
         [Command("forcead"), Summary("Force post ad")]
         [RequireUserPermission(GuildPermission.Administrator)]
-        async Task ForcePostAd()
+        public async Task ForcePostAd()
         {
             await _update.CheckDailyPublisher(true);
             await ReplyAsync("New ad posted.");
@@ -437,7 +437,7 @@ namespace DiscordBot.Modules
 
         [Command("dbsync"), Summary("Force add user to database")]
         [RequireUserPermission(GuildPermission.Administrator)]
-        async Task DbSync(IUser user)
+        public async Task DbSync(IUser user)
         {
             _database.AddNewUser((SocketGuildUser) user);
         }

--- a/DiscordBot/Modules/TicketModule.cs
+++ b/DiscordBot/Modules/TicketModule.cs
@@ -21,7 +21,7 @@ namespace DiscordBot.Modules
         /// One command, no args, simple.
         /// </summary>
         [Command("complain"), Alias("complains", "complaint"), Summary("Opens a private channel to complain. Syntax : !complain")]
-        private async Task Complaint()
+        public async Task Complaint()
         {
             var channelList = Context.Guild.GetChannelsAsync().Result;
             var hash = Context.User.Id.ToString().GetSHA256().Substring(0, 8);
@@ -75,7 +75,7 @@ namespace DiscordBot.Modules
         /// </summary>
         [Command("close"), Alias("end", "done", "bye"), Summary("Closes the ticket")]
         [RequireUserPermission(GuildPermission.ManageRoles)]
-        private async Task Close()
+        public async Task Close()
         {
             var channelName = _settings.ComplaintChannelPrefix;
 

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -48,7 +48,7 @@ namespace DiscordBot.Modules
 
         [Command("help"), Summary("Display available commands (this). Syntax : !help")]
         [Alias("command", "commands")]
-        private async Task DisplayHelp()
+        public async Task DisplayHelp()
         {
             //TODO: Be possible in DM
             if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
@@ -67,7 +67,7 @@ namespace DiscordBot.Modules
         #region Rules
 
         [Command("rules"), Summary("Get the of the current channel by DM. Syntax : !rules")]
-        private async Task Rules()
+        public async Task Rules()
         {
             await Rules(Context.Channel);
             await Context.Message.DeleteAsync();
@@ -75,7 +75,7 @@ namespace DiscordBot.Modules
 
         [Command("rules"), Summary("Get the rules of the mentionned channel by DM. !rules #channel")]
         [Alias("rule")]
-        private async Task Rules(IMessageChannel channel)
+        public async Task Rules(IMessageChannel channel)
         {
             var rule = _rules.Channel.First(x => x.Id == channel.Id);
             //IUserMessage m; //Unused, plan to be used in future?
@@ -96,7 +96,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("globalrules"), Summary("Get the Global Rules by DM. Syntax : !globalrules")]
-        private async Task GlobalRules(int seconds = 60)
+        public async Task GlobalRules(int seconds = 60)
         {
             string globalRules = _rules.Channel.First(x => x.Id == 0).Content;
             IDMChannel dm = await Context.User.GetOrCreateDMChannelAsync();
@@ -105,7 +105,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("channels"), Summary("Get description of the channels by DM. Syntax : !channels")]
-        private async Task ChannelsDescription()
+        public async Task ChannelsDescription()
         {
             //Display rules of this channel for x seconds
             var channelData = _rules.Channel;
@@ -134,7 +134,7 @@ namespace DiscordBot.Modules
         #region XP & Karma
 
         [Command("karma"), Summary("Display description of what Karma is for. Syntax : !karma")]
-        private async Task KarmaDescription(int seconds = 60)
+        public async Task KarmaDescription(int seconds = 60)
         {
             await ReplyAsync($"{Context.User.Username}, " +
                              $"Karma is tracked on your !profile, helping indicate how much you've helped others.{Environment.NewLine}" +
@@ -146,7 +146,7 @@ namespace DiscordBot.Modules
 
         [Command("top"), Summary("Display top 10 users by level. Syntax : !top")]
         [Alias("toplevel", "ranking")]
-        private async Task TopLevel()
+        public async Task TopLevel()
         {
             var users = _databaseService.GetTopLevel();
 
@@ -161,7 +161,7 @@ namespace DiscordBot.Modules
 
         [Command("topkarma"), Summary("Display top 10 users by karma. Syntax : !topkarma")]
         [Alias("karmarank", "rankingkarma")]
-        private async Task TopKarma()
+        public async Task TopKarma()
         {
             var users = _databaseService.GetTopKarma();
 
@@ -176,7 +176,7 @@ namespace DiscordBot.Modules
 
         [Command("topudc"), Summary("Display top 10 users by UDC. Syntax : !topudc")]
         [Alias("udcrank")]
-        private async Task TopUdc()
+        public async Task TopUdc()
         {
             var users = _databaseService.GetTopUdc();
 
@@ -189,7 +189,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("profile"), Summary("Display current user profile card. Syntax : !profile")]
-        private async Task DisplayProfile()
+        public async Task DisplayProfile()
         {
             IUserMessage profile =
                 await Context.Channel.SendFileAsync(await _userService.GenerateProfileCard(Context.Message.Author));
@@ -201,7 +201,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("profile"), Summary("Display profile card of mentionned user. Syntax : !profile @user")]
-        private async Task DisplayProfile(IUser user)
+        public async Task DisplayProfile(IUser user)
         {
             IUserMessage profile = await Context.Channel.SendFileAsync(await _userService.GenerateProfileCard(user));
 
@@ -212,7 +212,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("joindate"), Summary("Display your join date. Syntax : !joindate")]
-        private async Task JoinDate()
+        public async Task JoinDate()
         {
             var userId = Context.User.Id;
             DateTime.TryParse(_databaseService.GetUserJoinDate(userId), out DateTime joinDate);
@@ -226,7 +226,7 @@ namespace DiscordBot.Modules
 
         [Command("codetip"), Summary("Show code formatting example. Syntax : !codetip userToPing(optional)")]
         [Alias("codetips")]
-        private async Task CodeTip(IUser user = null)
+        public async Task CodeTip(IUser user = null)
         {
             var message = (user != null) ? user.Mention + ", " : "";
             message += "When posting code, format it like this to display it properly:" + Environment.NewLine;
@@ -237,7 +237,7 @@ namespace DiscordBot.Modules
 
         [Command("disablecodetips"),
          Summary("Prevents being reminded about using proper code formatting when code is detected. Syntax : !disablecodetips")]
-        private async Task DisableCodeTips()
+        public async Task DisableCodeTips()
         {
             ulong userID = Context.User.Id;
             string replyMessage = "You've already told me to stop reminding you, don't worry, I won't forget!";
@@ -256,7 +256,7 @@ namespace DiscordBot.Modules
 
         [Command("disablethanksreminder"),
          Summary("Prevents being reminded to mention the person you are thanking. Syntax : !disablethanksreminder")]
-        private async Task DisableThanksReminder()
+        public async Task DisableThanksReminder()
         {
             ulong userID = Context.User.Id;
             string replyMessage = "You've already told me to stop reminding you, don't worry, I won't forget!";
@@ -273,7 +273,7 @@ namespace DiscordBot.Modules
 
 
         [Command("quote"), Summary("Quote a message. Syntax : !quote messageid (#channelname) (optionalSubtitle)")]
-        private async Task QuoteMessage(ulong id, IMessageChannel channel = null, string subtitle = null)
+        public async Task QuoteMessage(ulong id, IMessageChannel channel = null, string subtitle = null)
         {
             if (subtitle != null && (subtitle.Contains("@everyone") || subtitle.Contains("@here"))) return;
             // If channel is null use Context.Channel, else use the provided channel
@@ -310,7 +310,7 @@ namespace DiscordBot.Modules
         [Command("compile"),
          Summary("Try to compile a snippet of C# code. Be sure to escape your strings. Syntax : !compile \"Your code\"")]
         [Alias("code", "compute", "assert")]
-        private async Task CompileCode(params string[] code)
+        public async Task CompileCode(params string[] code)
         {
             var codeComplete = Resources.PaizaCodeTemplate.Replace("{code}", string.Join(" ", code));
 
@@ -379,7 +379,7 @@ namespace DiscordBot.Modules
         #region Fun
 
         [Command("slap"), Summary("Slap the specified user(s). Syntax : !slap @user1 [@user2 @user3...]")]
-        private async Task SlapUser(params IUser[] users)
+        public async Task SlapUser(params IUser[] users)
         {
             StringBuilder sb = new StringBuilder();
             string[] slaps = {"trout", "duck", "truck"};
@@ -401,7 +401,7 @@ namespace DiscordBot.Modules
 
         [Command("coinflip"), Summary("Flip a coin and see the result. Syntax : !coinflip")]
         [Alias("flipcoin")]
-        private async Task CoinFlip()
+        public async Task CoinFlip()
         {
             Random rand = new Random();
             var coin = new[] {"Heads", "Tails"};
@@ -429,7 +429,7 @@ namespace DiscordBot.Modules
 
         [Command("pinfo"), Summary("Information on how to get the publisher role. Syntax : !pinfo")]
         [Alias("publisherinfo")]
-        private async Task PublisherInfo()
+        public async Task PublisherInfo()
         {
             if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
             {
@@ -452,7 +452,7 @@ namespace DiscordBot.Modules
 
         [Command("pkg"), Summary("Add your published package to the daily advertising. Syntax : !pkg packageId")]
         [Alias("package")]
-        private async Task Package(uint packageId)
+        public async Task Package(uint packageId)
         {
             if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
             {
@@ -466,7 +466,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("verify"), Summary("Verify a package with the code received by email. Syntax : !verify packageId code")]
-        private async Task VerifyPackage(uint packageId, string code)
+        public async Task VerifyPackage(uint packageId, string code)
         {
             if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
             {
@@ -485,7 +485,7 @@ namespace DiscordBot.Modules
 
         [Command("search"), Summary("Searches on DuckDuckGo for web results. Syntax : !search \"query\" resNum site")]
         [Alias("s", "ddg")]
-        private async Task SearchResults(string query, uint resNum = 3, string site = "")
+        public async Task SearchResults(string query, uint resNum = 3, string site = "")
         {
             // Cleaning inputs from user (maybe we can ban certain domains or keywords)
             resNum = resNum <= 5 ? resNum : 5;
@@ -537,7 +537,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("manual"), Summary("Searches on Unity3D manual results. Syntax : !manual \"query\"")]
-        private async Task SearchManual(params string[] queries)
+        public async Task SearchManual(params string[] queries)
         {
             // Download Unity3D Documentation Database (lol)
 
@@ -565,7 +565,7 @@ namespace DiscordBot.Modules
 
         [Command("doc"), Summary("Searches on Unity3D API results. Syntax : !api \"query\"")]
         [Alias("ref", "reference", "api", "docs")]
-        private async Task SearchApi(params string[] queries)
+        public async Task SearchApi(params string[] queries)
         {
             // Download Unity3D Documentation Database (lol)
 
@@ -614,7 +614,7 @@ namespace DiscordBot.Modules
         }
 
         [Command("faq"), Summary("Searches UDH FAQs. Syntax : !faq \"query\"")]
-        private async Task SearchFaqs(params string[] queries)
+        public async Task SearchFaqs(params string[] queries)
         {
             List<FaqData> faqDataList = _updateService.GetFaqData();
 
@@ -708,7 +708,7 @@ namespace DiscordBot.Modules
 
         [Command("wiki"), Summary("Searches Wikipedia. Syntax : !wiki \"query\"")]
         [Alias("wikipedia")]
-        private async Task SearchWikipedia([Remainder] string query)
+        public async Task SearchWikipedia([Remainder] string query)
         {
             (string name, string extract, string url) article = await _updateService.DownloadWikipediaArticle(query);
 
@@ -751,7 +751,7 @@ namespace DiscordBot.Modules
 
         [Command("birthday"), Summary("Display next member birthday. Syntax : !birthday")]
         [Alias("bday")]
-        private async Task Birthday()
+        public async Task Birthday()
         {
             // URL to cell C15/"Next birthday" cell from Corn's google sheet
             string nextBirthday =
@@ -769,7 +769,7 @@ namespace DiscordBot.Modules
 
         [Command("birthday"), Summary("Display birthday of mentioned user. Syntax : !birthday @user")]
         [Alias("bday")]
-        private async Task Birthday(IUser user)
+        public async Task Birthday(IUser user)
         {
             string searchName = user.Username;
             // URL to columns B to D of Corn's google sheet
@@ -858,13 +858,13 @@ namespace DiscordBot.Modules
         #region temperatures
 
         [Command("ftoc"), Summary("Converts a temperature in fahrenheit to celsius. Syntax : !ftoc temperature")]
-        private async Task FahrenheitToCelsius(float f)
+        public async Task FahrenheitToCelsius(float f)
         {
             await ReplyAsync($"{Context.User.Mention} {f}°F is {Math.Round((f - 32) * 0.555555f, 2)}°C.");
         }
 
         [Command("ctof"), Summary("Converts a temperature in celsius to fahrenheit. Syntax : !ftoc temperature")]
-        private async Task CelsiusToFahrenheit(float c)
+        public async Task CelsiusToFahrenheit(float c)
         {
             await ReplyAsync($"{Context.User.Mention}  {c}°C is {Math.Round(c * 1.8f + 32, 2)}°F");
         }
@@ -874,13 +874,13 @@ namespace DiscordBot.Modules
         #region Translate
 
         [Command("translate"), Summary("Translate a message. Syntax : !translate messageId language")]
-        private async Task Translate(ulong id, string language = "en")
+        public async Task Translate(ulong id, string language = "en")
         {
             await Translate((await Context.Channel.GetMessageAsync(id)).Content, language);
         }
 
         [Command("translate"), Summary("Translate a message. Syntax : !translate text language")]
-        private async Task Translate(string message, string language = "en")
+        public async Task Translate(string message, string language = "en")
         {
             await ReplyAsync($"Here: https://translate.google.com/#auto/{language}/{message.Replace(" ", "%20")}");
             await Task.Delay(1000);
@@ -893,14 +893,14 @@ namespace DiscordBot.Modules
 
         [Command("currency"), Summary("Converts a currency. Syntax : !currency fromCurrency toCurrency")]
         [Alias("curr")]
-        private async Task ConvertCurrency(string from, string to)
+        public async Task ConvertCurrency(string from, string to)
         {
             await ConvertCurrency(1, from, to);
         }
 
         [Command("currency"), Summary("Converts a currency. Syntax : !currency amount fromCurrency toCurrency")]
         [Alias("curr")]
-        private async Task ConvertCurrency(double amount, string from, string to)
+        public async Task ConvertCurrency(double amount, string from, string to)
         {
             from = from.ToUpper();
             to = to.ToUpper();
@@ -927,7 +927,7 @@ namespace DiscordBot.Modules
 
         [Command("ping"), Summary("Display bot ping. Syntax : !ping")]
         [Alias("pong")]
-        private async Task Ping()
+        public async Task Ping()
         {
             var message = await ReplyAsync($"Pong :blush:");
             var time = message.CreatedAt.Subtract(Context.Message.Timestamp);
@@ -941,7 +941,7 @@ namespace DiscordBot.Modules
 
         [Command("members"), Summary("Displays number of members Syntax : !members")]
         [Alias("MemberCount")]
-        private async Task MemberCount()
+        public async Task MemberCount()
         {
             await ReplyAsync(
                 $"We currently have {(await Context.Guild.GetUsersAsync()).Count - 1} members. Let's keep on growing as the strong community we are :muscle:");
@@ -958,7 +958,7 @@ namespace DiscordBot.Modules
             }
 
             [Command("add"), Summary("Add a role to yourself. Syntax : !role add role")]
-            private async Task AddRoleUser(IRole role)
+            public async Task AddRoleUser(IRole role)
             {
                 if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
                 {
@@ -982,7 +982,7 @@ namespace DiscordBot.Modules
 
             [Command("remove"), Summary("Remove a role from yourself. Syntax : !role remove role")]
             [Alias("delete")]
-            private async Task RemoveRoleUser(IRole role)
+            public async Task RemoveRoleUser(IRole role)
             {
                 if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
                 {
@@ -1005,7 +1005,7 @@ namespace DiscordBot.Modules
             }
 
             [Command("list"), Summary("Display the list of roles. Syntax : !role list")]
-            private async Task ListRole()
+            public async Task ListRole()
             {
                 if (Context.Channel.Id != _settings.BotCommandsChannel.Id)
                 {
@@ -1044,7 +1044,7 @@ namespace DiscordBot.Modules
         }
         
         [Command("ChristmasCompleted"), Summary("Gives rewards to people who complete the christmas event.")]
-        private async Task UserCompleted(String message)
+        public async Task UserCompleted(String message)
         {
 
             //Make sure they're the santa bot
@@ -1077,7 +1077,7 @@ namespace DiscordBot.Modules
             }
 
             [Command("search"), Summary("Returns an anime. Syntax : !anime search animeTitle")]
-            private async Task SearchAnime(string title)
+            public async Task SearchAnime(string title)
             {
                 /*{
                   "content": "Here's your search result @blabla",


### PR DESCRIPTION
This allows users to get Karma from replies which were recently added to discord.

- Updates DiscordNet from 2.2 to 2.3
- Makes Private [Commands] Public due to command discovery problem after updating to 2.3. (see note)

Note: Once upgraded I found none of the commands were discoverable by the bot, I went looking for information and debugged for a bit. I found that the commands using Private methods were not being hooked, I fixed this by making them Public. I'm not sure if there is an altenative way to fixing this as I found no information in update logs about this.